### PR TITLE
remove Perf stub classes from resulting jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,17 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.13</version>
             </plugin>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>jdk/**</exclude>
+                        <exclude>sun/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
existence of /jdk/internal/perf/Perf.class in resulting jar may lead to  
"java.lang.LayerInstantiationException: Package jdk.internal.perf in both module jvm.attach.api and module java.base" during initialization of boot layer under modern jdk